### PR TITLE
refactor: move ads feature to feature-first structure

### DIFF
--- a/app/api/ads/route.ts
+++ b/app/api/ads/route.ts
@@ -1,247 +1,49 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createSupabaseServer } from "@/lib/supabase/server";
 
-// Perspectivas e seus competidores
-const PERSPECTIVE_COMPETITORS = {
-  infinitepay: ["PagBank", "Stone", "Cora", "Ton", "Mercado Pago", "Jeitto"],
-  jim: ["Square", "PayPal", "Stripe", "Venmo", "SumUp"],
-  cloudwalk: [], // todos
-  default: [], // todos
-} as const;
+import { fetchAds, parseAdsRequestParams } from "@/features/ads/server";
+import { createSupabaseServer } from "@/lib/supabase/server";
 
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
 
   try {
-    console.log("\n🔍 ===== NOVA REQUISIÇÃO API /ads =====");
-    console.log(`⏰ Timestamp: ${new Date().toISOString()}`);
-
-    // Verificar se as variáveis de ambiente estão configuradas
     if (
       !process.env.NEXT_PUBLIC_SUPABASE_URL ||
       !process.env.SUPABASE_SERVICE_ROLE_KEY
     ) {
-      console.log("❌ ERRO: Variáveis de ambiente não configuradas");
       return NextResponse.json(
         {
           error:
-            "Supabase não configurado. Verifique as variáveis de ambiente no arquivo .env.local",
+            "Supabase environment variables are missing. Check NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
         },
         { status: 500 },
       );
     }
 
-    // Criar cliente Supabase
     const supabase = await createSupabaseServer();
-    console.log("✅ Cliente Supabase criado");
+    const params = parseAdsRequestParams(request);
 
-    const { searchParams } = new URL(request.url);
-    console.log("📋 URL completa:", request.url);
+    const result = await fetchAds({ supabase }, params);
 
-    // Parâmetros de paginação
-    const page = parseInt(searchParams.get("page") || "1");
-    const limit = parseInt(searchParams.get("limit") || "24");
-    const offset = (page - 1) * limit;
-
-    // Parâmetros de filtro
-    const perspective =
-      (searchParams.get(
-        "perspective",
-      ) as keyof typeof PERSPECTIVE_COMPETITORS) || "default";
-    const competitors = searchParams.get("competitors")?.split(",") || [];
-    const assetTypes = searchParams.get("assetTypes")?.split(",") || [];
-    const products = searchParams.get("products")?.split(",") || [];
-    const search = searchParams.get("search") || "";
-    const dateFrom = searchParams.get("dateFrom");
-    const dateTo = searchParams.get("dateTo");
-    console.log("--------------------------------");
-    console.log("📊 PARÂMETROS RECEBIDOS:");
-    console.log(`   📄 Página: ${page}, Limite: ${limit}, Offset: ${offset}`);
-    console.log(`   🎯 Perspectiva: ${perspective}`);
-    console.log(
-      `   👥 Competidores: ${competitors.length > 0 ? competitors.join(", ") : "TODOS"}`,
-    );
-    console.log(
-      `   🎨 Tipos de Asset: ${assetTypes.length > 0 ? assetTypes.join(", ") : "TODOS"}`,
-    );
-    console.log(
-      `   📦 Produtos: ${products.length > 0 ? products.join(", ") : "TODOS"}`,
-    );
-    console.log(`   🔍 Busca: ${search || "NENHUMA"}`);
-    console.log(`   📅 Data De: ${dateFrom || "NENHUMA"}`);
-    console.log(`   📅 Data Até: ${dateTo || "NENHUMA"}`);
-
-    // Resolver competidores da perspectiva
-    let competitorIds: string[] = [];
-    const perspectiveCompetitors = PERSPECTIVE_COMPETITORS[perspective];
-
-    console.log("🏢 RESOLVENDO PERSPECTIVA:");
-    console.log(`   📋 Perspectiva: ${perspective}`);
-    console.log(
-      `   👥 Competidores da perspectiva: ${perspectiveCompetitors.length > 0 ? perspectiveCompetitors.join(", ") : "TODOS (sem filtro)"}`,
-    );
-
-    if (perspectiveCompetitors.length > 0) {
-      // Buscar UUIDs dos competidores da perspectiva
-      const { data: competitorData, error: competitorError } = await supabase
-        .from("competitors")
-        .select("id, name")
-        .in("name", perspectiveCompetitors);
-
-      if (competitorError) {
-        console.error("❌ Erro ao buscar competidores:", competitorError);
-        return NextResponse.json(
-          { error: `Erro ao buscar competidores: ${competitorError.message}` },
-          { status: 500 },
-        );
-      }
-
-      competitorIds = competitorData?.map((c) => c.id) || [];
-      console.log(
-        `   ✅ UUIDs encontrados: ${competitorIds.length} competidores`,
-      );
-      console.log(
-        `   📝 Detalhes:`,
-        competitorData?.map((c) => `${c.name} (${c.id})`).join(", "),
-      );
-    } else {
-      console.log(
-        "   ℹ️  Sem filtro de perspectiva - buscando TODOS os competidores",
-      );
-    }
-
-    // Construir query base
-    let query = supabase.from("ads").select(
-      `
-        ad_id,
-        competitor_id,
-        source,
-        asset_type,
-        product,
-        start_date,
-        display_format,
-        tags,
-        image_description,
-        transcription,
-        ad_analysis,
-        created_at,
-        competitors!ads_competitor_id_fkey (
-          name,
-          home_url
-        )
-      `,
-      { count: "exact" },
-    );
-
-    // Aplicar filtros de validação (Marco 1)
-    query = query
-      .not("ad_analysis", "is", null)
-      .neq("ad_analysis", "{}")
-      .in("asset_type", ["video", "image"]);
-
-    // Filtro por perspectiva (competidores)
-    if (competitorIds.length > 0) {
-      query = query.in("competitor_id", competitorIds);
-    }
-
-    // Filtros adicionais
-    if (competitors.length > 0) {
-      query = query.in("competitor_id", competitors);
-    }
-
-    if (assetTypes.length > 0) {
-      query = query.in("asset_type", assetTypes);
-    }
-
-    if (products.length > 0) {
-      query = query.in("product", products);
-    }
-
-    if (search) {
-      query = query.or(
-        `tags.ilike.%${search}%,image_description.ilike.%${search}%,transcription.ilike.%${search}%,product.ilike.%${search}%`,
-      );
-    }
-
-    if (dateFrom) {
-      // Converter YYYY-MM-DD para início do dia em São Paulo (UTC-3)
-      const fromDate = new Date(`${dateFrom}T00:00:00.000-03:00`).toISOString();
-      query = query.gte("start_date", fromDate);
-    }
-
-    if (dateTo) {
-      // Converter YYYY-MM-DD para fim do dia em São Paulo (UTC-3)
-      const toDate = new Date(`${dateTo}T23:59:59.999-03:00`).toISOString();
-      query = query.lte("start_date", toDate);
-    }
-
-    // Filtro de qualidade: pelo menos um campo de conteúdo não vazio
-    query = query.or("transcription.neq.,image_description.neq.,tags.neq.");
-
-    // Ordenação e paginação
-    query = query
-      .order("start_date", { ascending: false, nullsFirst: false })
-      .order("created_at", { ascending: false })
-      .range(offset, offset + limit - 1);
-
-    console.log("🔍 EXECUTANDO QUERY NO SUPABASE...");
-
-    const { data: ads, error, count } = await query;
-
-    if (error) {
-      console.error("❌ ERRO DO SUPABASE:", error);
-      return NextResponse.json(
-        { error: `Erro ao buscar anúncios: ${error.message}` },
-        { status: 500 },
-      );
-    }
-
-    const endTime = Date.now();
-    const duration = endTime - startTime;
-
-    console.log("📊 RESULTADO DA QUERY:");
-    console.log(`   ✅ Total no banco (count): ${count || 0}`);
-    console.log(`   📄 Anúncios retornados: ${ads?.length || 0}`);
-    console.log(
-      `   📄 Página atual: ${page} de ${Math.ceil((count || 0) / limit)}`,
-    );
-    console.log(`   ⏱️  Tempo de execução: ${duration}ms`);
-
-    if (ads && ads.length > 0) {
-      console.log("📋 PRIMEIROS 3 ANÚNCIOS:");
-      ads.slice(0, 3).forEach((ad, index) => {
-        console.log(
-          `   ${index + 1}. ID: ${ad.ad_id} | Competidor: ${(ad.competitors as any)?.name} | Data: ${ad.start_date}`,
-        );
-      });
-    } else {
-      console.log("⚠️  NENHUM ANÚNCIO RETORNADO!");
-    }
-
-    // Processar dados para o formato esperado
-    const processedAds = (ads || []).map((ad: any) => ({
-      ...ad,
-      competitor: ad.competitors,
-      variations_count: 0, // Será implementado depois se necessário
-    }));
-
-    console.log("🏁 ===== FIM DA REQUISIÇÃO =====\n");
-
-    return NextResponse.json({
-      ads: processedAds,
-      pagination: {
-        page,
-        limit,
-        total: count || 0,
-        totalPages: Math.ceil((count || 0) / limit),
-      },
-      perspective,
-      competitorIds: competitorIds.length > 0 ? competitorIds : null,
+    const duration = Date.now() - startTime;
+    console.info("[api/ads] request completed", {
+      page: params.page,
+      limit: params.limit,
+      perspective: params.perspective,
+      competitors: params.competitors,
+      assetTypes: params.assetTypes,
+      products: params.products,
+      search: params.search,
+      dateFrom: params.dateFrom,
+      dateTo: params.dateTo,
+      durationMs: duration,
     });
+
+    return NextResponse.json(result);
   } catch (error) {
-    console.error("Erro na API de anúncios:", error);
+    console.error("[api/ads] unexpected error", error);
     return NextResponse.json(
-      { error: "Erro interno do servidor" },
+      { error: "Internal server error" },
       { status: 500 },
     );
   }

--- a/components/AdsExplorer.tsx
+++ b/components/AdsExplorer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { useAds, Perspective } from "@/hooks/useAds";
-import { AdsGrid } from "./ads/AdsGrid";
+import { useAds } from "@/features/ads/hooks";
+import { DEFAULT_PERSPECTIVE, type Perspective } from "@/features/ads/types";
+import { AdsGrid } from "@/features/ads/components/AdsGrid";
 import { PerspectiveSelector } from "./PerspectiveSelector";
 import { Card } from "@/shared/ui/card";
 import { Badge } from "@/shared/ui/badge";
@@ -12,7 +13,7 @@ import { RefreshCw } from "lucide-react";
 const RECENCY_ACTIVE_DAYS = 2;
 
 export function AdsExplorer() {
-  const [perspective, setPerspective] = useState<Perspective>("default");
+  const [perspective, setPerspective] = useState<Perspective>(DEFAULT_PERSPECTIVE);
   const [page, setPage] = useState(1);
 
   const { ads, loading, error, pagination, refetch } = useAds({

--- a/components/PerspectiveSelector.tsx
+++ b/components/PerspectiveSelector.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from "@/shared/ui/select";
 import { Badge } from "@/shared/ui/badge";
-import { Perspective } from "@/hooks/useAds";
+import type { Perspective } from "@/features/ads/types";
 
 interface PerspectiveSelectorProps {
   value: Perspective;

--- a/components/ad-dashboard.tsx
+++ b/components/ad-dashboard.tsx
@@ -13,14 +13,14 @@ import { CompetitiveAnalysis } from "@/components/competitive-analysis";
 import { CompetitiveDashboard } from "@/components/competitive-dashboard";
 import { TrendAnalysis } from "@/components/trend-analysis";
 import { RateExtractor } from "@/components/rate-extractor";
-import { AdCard } from "@/components/ads/AdCard";
-import { useAds } from "@/hooks/useAds";
+import { AdCard } from "@/features/ads/components/AdCard";
+import { useAds } from "@/features/ads/hooks";
 import { useCompetitors } from "@/hooks/useCompetitors";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { useTheme } from "@/components/theme-provider";
 import { LogoLoading } from "@/shared/ui/logo-loading";
 import { X } from "lucide-react";
-import type { Ad } from "@/lib/types";
+import type { Ad } from "@/features/ads/types";
 
 // Função para formatar e limpar o ad_analysis
 function formatAdAnalysis(analysis: string | any): React.ReactElement {

--- a/features/ads/components/AdCard.tsx
+++ b/features/ads/components/AdCard.tsx
@@ -5,7 +5,7 @@ import { Card } from "@/shared/ui/card";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { Calendar, ExternalLink, Play, Image as ImageIcon } from "lucide-react";
-import { Ad } from "@/lib/types";
+import type { Ad } from "@/features/ads/types";
 
 interface AdCardProps {
   ad: Ad;

--- a/features/ads/components/AdsGrid.tsx
+++ b/features/ads/components/AdsGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AdCard } from "./AdCard";
-import { Ad } from "@/lib/types";
+import type { Ad } from "@/features/ads/types";
 import { Skeleton } from "@/shared/ui/skeleton";
 
 interface AdsGridProps {

--- a/features/ads/components/ProductBadge.tsx
+++ b/features/ads/components/ProductBadge.tsx
@@ -2,7 +2,7 @@
 
 import { Badge } from "@/shared/ui/badge";
 import { extractProductFromAd } from "@/lib/utils/ratesExtractor";
-import type { Ad } from "@/lib/types";
+import type { Ad } from "@/features/ads/types";
 
 interface ProductBadgeProps {
   ad: Ad;

--- a/features/ads/components/RatesDisplay.tsx
+++ b/features/ads/components/RatesDisplay.tsx
@@ -5,7 +5,7 @@ import {
   extractRatesFromAd,
   formatRateForDisplay,
 } from "@/lib/utils/ratesExtractor";
-import type { Ad } from "@/lib/types";
+import type { Ad } from "@/features/ads/types";
 
 interface RatesDisplayProps {
   ad: Ad;

--- a/features/ads/hooks/index.ts
+++ b/features/ads/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./useAds";
+export * from "./useFilteredAds";

--- a/features/ads/hooks/useAds.ts
+++ b/features/ads/hooks/useAds.ts
@@ -1,20 +1,19 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Ad, FilterState } from "@/lib/types";
-
-export type Perspective = "infinitepay" | "jim" | "cloudwalk" | "default";
+import { DEFAULT_PERSPECTIVE } from "@/features/ads/types";
+import type {
+  Ad,
+  AdsPagination,
+  FilterState,
+  Perspective,
+} from "@/features/ads/types";
 
 interface UseAdsResult {
   ads: Ad[];
   loading: boolean;
   error: string | null;
-  pagination: {
-    page: number;
-    limit: number;
-    total: number;
-    totalPages: number;
-  };
+  pagination: AdsPagination;
   perspective: Perspective;
   refetch: () => void;
 }
@@ -30,7 +29,7 @@ export function useAds(options: UseAdsOptions = {}): UseAdsResult {
   const [ads, setAds] = useState<Ad[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [pagination, setPagination] = useState({
+  const [pagination, setPagination] = useState<AdsPagination>({
     page: options.page || 1,
     limit: options.limit || 24,
     total: 0,
@@ -133,7 +132,7 @@ export function useAds(options: UseAdsOptions = {}): UseAdsResult {
     loading,
     error,
     pagination,
-    perspective: options.perspective || "default",
+    perspective: options.perspective || DEFAULT_PERSPECTIVE,
     refetch: fetchAds,
   };
 }

--- a/features/ads/hooks/useFilteredAds.ts
+++ b/features/ads/hooks/useFilteredAds.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useTheme } from "@/components/theme-provider";
 import { mockAds } from "@/lib/mock-data";
-import type { Ad } from "@/lib/types";
+import type { Ad } from "@/features/ads/types";
 
 // Hook que filtra anúncios baseado no tema atual
 export function useFilteredAds() {

--- a/features/ads/index.ts
+++ b/features/ads/index.ts
@@ -1,1 +1,3 @@
-export {}
+export * from "./types";
+export * from "./hooks";
+export * from "./server";

--- a/features/ads/server/constants.ts
+++ b/features/ads/server/constants.ts
@@ -1,0 +1,15 @@
+import type { Perspective } from "@/features/ads/types";
+
+export const PERSPECTIVE_COMPETITORS: Record<Perspective, readonly string[]> = {
+  infinitepay: [
+    "PagBank",
+    "Stone",
+    "Cora",
+    "Ton",
+    "Mercado Pago",
+    "Jeitto",
+  ],
+  jim: ["Square", "PayPal", "Stripe", "Venmo", "SumUp"],
+  cloudwalk: [],
+  default: [],
+};

--- a/features/ads/server/index.ts
+++ b/features/ads/server/index.ts
@@ -1,0 +1,3 @@
+export * from "./constants";
+export * from "./params";
+export * from "./service";

--- a/features/ads/server/params.ts
+++ b/features/ads/server/params.ts
@@ -1,0 +1,46 @@
+import type { NextRequest } from "next/server";
+
+import {
+  DEFAULT_PERSPECTIVE,
+  isPerspective,
+  type AdsRequestParams,
+  type Perspective,
+} from "@/features/ads/types";
+
+function parseNumber(value: string | null, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseList(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parsePerspective(value: string | null): Perspective {
+  return isPerspective(value) ? value : DEFAULT_PERSPECTIVE;
+}
+
+export function parseAdsRequestParams(request: NextRequest): AdsRequestParams {
+  const { searchParams } = new URL(request.url);
+
+  const page = parseNumber(searchParams.get("page"), 1);
+  const limit = parseNumber(searchParams.get("limit"), 24);
+  const perspective = parsePerspective(searchParams.get("perspective"));
+
+  return {
+    page,
+    limit,
+    perspective,
+    competitors: parseList(searchParams.get("competitors")),
+    assetTypes: parseList(searchParams.get("assetTypes")),
+    products: parseList(searchParams.get("products")),
+    search: searchParams.get("search") || "",
+    dateFrom: searchParams.get("dateFrom") || undefined,
+    dateTo: searchParams.get("dateTo") || undefined,
+  };
+}

--- a/features/ads/server/service.ts
+++ b/features/ads/server/service.ts
@@ -1,0 +1,185 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  type Ad,
+  type AdsRequestParams,
+  type AdsServiceResult,
+  type Perspective,
+} from "@/features/ads/types";
+import { PERSPECTIVE_COMPETITORS } from "./constants";
+
+interface AdsSupabaseRow {
+  ad_id: string;
+  competitor_id: string;
+  source?: string | null;
+  asset_type: "video" | "image";
+  product?: string | null;
+  start_date?: string | null;
+  display_format?: string | null;
+  tags?: string | null;
+  image_description?: string | null;
+  transcription?: string | null;
+  ad_analysis?: unknown;
+  created_at: string;
+  updated_at?: string | null;
+  competitors?: {
+    id?: string;
+    name?: string;
+    home_url?: string | null;
+  } | null;
+}
+
+interface FetchAdsDependencies {
+  supabase: SupabaseClient;
+}
+
+function parseDateBoundary(value?: string | null, end = false): string | undefined {
+  if (!value) return undefined;
+  const suffix = end ? "T23:59:59.999-03:00" : "T00:00:00.000-03:00";
+  const iso = new Date(`${value}${suffix}`).toISOString();
+  return iso;
+}
+
+async function resolvePerspectiveCompetitors(
+  supabase: SupabaseClient,
+  perspective: Perspective,
+): Promise<string[]> {
+  const competitorNames = PERSPECTIVE_COMPETITORS[perspective] ?? [];
+  if (competitorNames.length === 0) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("competitors")
+    .select("id, name")
+    .in("name", competitorNames);
+
+  if (error) {
+    throw new Error(`Failed to fetch competitors: ${error.message}`);
+  }
+
+  return data?.map((competitor) => competitor.id) ?? [];
+}
+
+function mapRowToAd(row: AdsSupabaseRow): Ad {
+  const {
+    competitors,
+    ...rest
+  } = row;
+
+  const competitor = competitors
+    ? {
+        id: competitors.id ?? rest.competitor_id,
+        name: competitors.name ?? "",
+        home_url: competitors.home_url ?? "",
+        created_at: rest.created_at,
+        updated_at: rest.updated_at ?? undefined,
+      }
+    : undefined;
+
+  return {
+    ...rest,
+    competitor,
+    variations_count: 0,
+  };
+}
+
+export async function fetchAds(
+  { supabase }: FetchAdsDependencies,
+  params: AdsRequestParams,
+): Promise<AdsServiceResult> {
+  const { page, limit } = params;
+  const offset = (page - 1) * limit;
+
+  const perspectiveIds = await resolvePerspectiveCompetitors(
+    supabase,
+    params.perspective,
+  );
+
+  let query = supabase
+    .from("ads")
+    .select(
+      `
+        ad_id,
+        competitor_id,
+        source,
+        asset_type,
+        product,
+        start_date,
+        display_format,
+        tags,
+        image_description,
+        transcription,
+        ad_analysis,
+        created_at,
+        updated_at,
+        competitors:competitors!ads_competitor_id_fkey (
+          id,
+          name,
+          home_url
+        )
+      `,
+      { count: "exact" },
+    )
+    .not("ad_analysis", "is", null)
+    .neq("ad_analysis", "{}")
+    .in("asset_type", ["video", "image"]);
+
+  if (perspectiveIds.length > 0) {
+    query = query.in("competitor_id", perspectiveIds);
+  }
+
+  if (params.competitors?.length) {
+    query = query.in("competitor_id", params.competitors);
+  }
+
+  if (params.assetTypes?.length) {
+    query = query.in("asset_type", params.assetTypes);
+  }
+
+  if (params.products?.length) {
+    query = query.in("product", params.products);
+  }
+
+  if (params.search) {
+    query = query.or(
+      `tags.ilike.%${params.search}%,image_description.ilike.%${params.search}%,transcription.ilike.%${params.search}%,product.ilike.%${params.search}%`,
+    );
+  }
+
+  const fromDate = parseDateBoundary(params.dateFrom, false);
+  if (fromDate) {
+    query = query.gte("start_date", fromDate);
+  }
+
+  const toDate = parseDateBoundary(params.dateTo, true);
+  if (toDate) {
+    query = query.lte("start_date", toDate);
+  }
+
+  query = query
+    .or("transcription.neq.,image_description.neq.,tags.neq.")
+    .order("start_date", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  const { data, error, count } = await query.returns<AdsSupabaseRow[]>();
+
+  if (error) {
+    throw new Error(`Failed to fetch ads: ${error.message}`);
+  }
+
+  const ads = (data ?? []).map((row) => mapRowToAd(row));
+
+  return {
+    ads,
+    pagination: {
+      page,
+      limit,
+      total: count ?? 0,
+      totalPages: Math.ceil((count ?? 0) / limit),
+    },
+    perspective: params.perspective,
+    competitorIds: perspectiveIds.length > 0 ? perspectiveIds : null,
+  };
+}

--- a/features/ads/types/index.ts
+++ b/features/ads/types/index.ts
@@ -1,0 +1,43 @@
+export type { Ad, FilterState } from "@/lib/types";
+
+export type Perspective = "infinitepay" | "jim" | "cloudwalk" | "default";
+export const DEFAULT_PERSPECTIVE: Perspective = "default";
+export const PERSPECTIVE_VALUES: Perspective[] = [
+  "infinitepay",
+  "jim",
+  "cloudwalk",
+  "default",
+];
+
+export function isPerspective(value: string | null): value is Perspective {
+  return value !== null && PERSPECTIVE_VALUES.includes(value as Perspective);
+}
+
+export interface AdsPagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface AdsFilters {
+  competitors?: string[];
+  assetTypes?: string[];
+  products?: string[];
+  search?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface AdsRequestParams extends AdsFilters {
+  page: number;
+  limit: number;
+  perspective: Perspective;
+}
+
+export interface AdsServiceResult {
+  ads: Ad[];
+  pagination: AdsPagination;
+  perspective: Perspective;
+  competitorIds: string[] | null;
+}

--- a/prompt/prompt-ad-hub.md
+++ b/prompt/prompt-ad-hub.md
@@ -841,13 +841,13 @@ interface AdCard {
 }
 
 // Componente AdCard com interações
-// components/ads/AdCard.tsx
+// features/ads/components/AdCard.tsx
 'use client';
 
 import { useState } from 'react';
 import { Card } from '@/shared/ui/card';
 import { Badge } from '@/shared/ui/badge';
-import { RatesDisplay } from './RatesDisplay';
+import { RatesDisplay } from '@/features/ads/components/RatesDisplay';
 import { ProductBadge } from './ProductBadge';
 
 interface AdCardProps {
@@ -927,7 +927,7 @@ export function AdCard({ ad, onClick }: AdCardProps) {
 }
 
 // Componente RatesDisplay
-// components/ads/RatesDisplay.tsx
+// features/ads/components/RatesDisplay.tsx
 interface RatesDisplayProps {
   rates: {
     credit_pos?: string;
@@ -959,7 +959,7 @@ export function RatesDisplay({ rates }: RatesDisplayProps) {
 }
 
 // Componente ProductBadge
-// components/ads/ProductBadge.tsx
+// features/ads/components/ProductBadge.tsx
 interface ProductBadgeProps {
   product: string;
   type: 'video' | 'image';


### PR DESCRIPTION
## Summary
- relocate ads UI and hooks into `features/ads/**`
- expose typed params/services under `features/ads/server`
- slim `/api/ads` handler to delegate parsing and data access

## Testing
- npm run lint *(fails: pre-existing any/unused/img warnings in legacy code)*
